### PR TITLE
feat: Update node and mermaid versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-ARG BASE_IMAGE=node:10.16.3
+ARG BASE_IMAGE=node:15.5.0
 FROM ${BASE_IMAGE}
-
-MAINTAINER Matthew Feickert <matthewfeickert@users.noreply.github.com>
 
 USER root
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,7 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Pin at versions of Docker image build
-# FIXME: phantomjs is deprecated
-RUN yarn global add phantomjs-prebuilt@2.1.16 && \
+RUN yarn global add puppeteer@5.5.0 && \
     yarn global add mermaid@8.8.4 && \
     yarn global add mermaid.cli@0.5.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ SHELL [ "/bin/bash", "-c" ]
 
 # c.f. https://techoverflow.net/2018/06/05/how-to-fix-puppetteer-error-while-loading-shared-libraries-libx11-xcb-so-1-cannot-open-shared-object-file-no-such-file-or-directory/
 RUN apt-get -qq -y update && \
-    apt-get -qq -y upgrade && \
     apt-get -qq -y install \
         gconf-service \
         libasound2 \
@@ -49,7 +48,7 @@ RUN apt-get -qq -y update && \
         xdg-utils wget && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt-get/lists/*
+    rm -rf /var/lib/apt/lists/*
 
 # Pin at versions of Docker image build
 # FIXME: phantomjs is deprecated

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get -qq -y update && \
 # Pin at versions of Docker image build
 # FIXME: phantomjs is deprecated
 RUN yarn global add phantomjs-prebuilt@2.1.16 && \
-    yarn global add mermaid@8.2.6 && \
+    yarn global add mermaid@8.8.4 && \
     yarn global add mermaid.cli@0.5.1
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get -qq -y update && \
 # Pin at versions of Docker image build
 RUN yarn global add puppeteer@5.5.0 && \
     yarn global add mermaid@8.8.4 && \
-    yarn global add mermaid.cli@0.5.1
+    yarn global add @mermaid-js/mermaid-cli@8.8.4
 
 # Use C.UTF-8 locale to avoid issues with ASCII encoding
 ENV LC_ALL=C.UTF-8

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ default: image
 all: image
 
 image:
-	docker build -f Dockerfile \
+	docker build \
+	--pull \
+	-f Dockerfile \
 	--cache-from matthewfeickert/mermaid-cli:latest \
-	--build-arg BASE_IMAGE=node:10.16.3 \
+	--build-arg BASE_IMAGE=node:15.5.0 \
 	-t matthewfeickert/mermaid-cli:latest \
-	-t matthewfeickert/mermaid-cli:node-10.16.3 \
-	-t matthewfeickert/mermaid-cli:node-dubnium \
+	-t matthewfeickert/mermaid-cli:node-15.5.0 \
 	--compress .

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,5 @@ image:
 	--build-arg BASE_IMAGE=node:15.5.0 \
 	-t matthewfeickert/mermaid-cli:latest \
 	-t matthewfeickert/mermaid-cli:node-15.5.0 \
+	-t matthewfeickert/mermaid-cli:mermaid-8.8.4 \
 	--compress .

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Docker image with headless [mermaid JS](https://mermaidjs.github.io/#/) and [mer
 
 All node dependencies installed with `yarn`
 
-- node [v10.16.3](https://nodejs.org/dist/v10.16.3/docs/api/)
-- [phantomjs-prebuilt](https://www.npmjs.com/package/phantomjs-prebuilt) [v2.1.16](https://www.npmjs.com/package/phantomjs-prebuilt/v/2.1.16) ![](https://img.shields.io/badge/package-deprecated-red.svg)
-- [mermaid](https://www.npmjs.com/package/mermaid) [v8.2.6](https://www.npmjs.com/package/mermaid/v/8.2.6)
-- [mermaid.cli](https://www.npmjs.com/package/mermaid.cli) [v0.5.1](https://www.npmjs.com/package/mermaid.cli/v/0.5.1)
+
+- node [v15.5.0](https://nodejs.org/dist/v15.5.0/docs/api/)
+- [puppeteer](https://www.npmjs.com/package/puppeteer) [v5.5.0](https://www.npmjs.com/package/puppeteer/v/5.5.0)
+- [mermaid](https://www.npmjs.com/package/mermaid) [v8.8.4](https://www.npmjs.com/package/mermaid/v/8.8.4)
+- [@mermaid-js/mermaid-cli](https://www.npmjs.com/package/@mermaid-js/mermaid-cli) [v8.8.4](https://www.npmjs.com/package/@mermaid-js/mermaid-cli/v/8.8.4)
 
 ## Install
 
@@ -33,3 +34,31 @@ docker run --rm -v $PWD:/home/node/data matthewfeickert/mermaid-cli:latest -i <i
 ```
 
 where `ext` is one of the supported extensions.
+
+To get a listing of all the options just run
+
+```
+docker run --rm matthewfeickert/mermaid-cli:latest
+```
+
+as the Docker image `CMD` is `--help`.
+
+```
+$ docker run --rm matthewfeickert/mermaid-cli:latest
+Usage: mmdc [options]
+
+Options:
+  -V, --version                                   output the version number
+  -t, --theme [theme]                             Theme of the chart, could be default, forest, dark or neutral. Optional. Default: default (default: "default")
+  -w, --width [width]                             Width of the page. Optional. Default: 800 (default: "800")
+  -H, --height [height]                           Height of the page. Optional. Default: 600 (default: "600")
+  -i, --input <input>                             Input mermaid file. Required.
+  -o, --output [output]                           Output file. It should be either svg, png or pdf. Optional. Default: input + ".svg"
+  -b, --backgroundColor [backgroundColor]         Background color. Example: transparent, red, '#F0F0F0'. Optional. Default: white
+  -c, --configFile [configFile]                   JSON configuration file for mermaid. Optional
+  -C, --cssFile [cssFile]                         CSS file for the page. Optional
+  -s, --scale [scale]                             Puppeteer scale factor, default 1. Optional
+  -f, --pdfFit                                    Scale PDF to fit chart
+  -p --puppeteerConfigFile [puppeteerConfigFile]  JSON configuration file for puppeteer. Optional
+  -h, --help                                      display help for command
+```


### PR DESCRIPTION
```
* Update node to v15.5.0
* Update mermaid to v8.8.4
* Add puppeteer v5.5.0
* Switch to using @mermaid-js/mermaid-cli v8.8.4
* Add --help example to README
```